### PR TITLE
Deleting unused functions in AzureIoT class

### DIFF
--- a/TELSTRA - RELEASE LIBRARIES AND EXAMPLES 05.04.2018/TEL-IOT5 - Arduino PRE-RELEASE LIBRARIES AND EXAMPLES 05.04.2018/Telstra Examples/8. Azure POST/azureIoT.cpp
+++ b/TELSTRA - RELEASE LIBRARIES AND EXAMPLES 05.04.2018/TEL-IOT5 - Arduino PRE-RELEASE LIBRARIES AND EXAMPLES 05.04.2018/Telstra Examples/8. Azure POST/azureIoT.cpp
@@ -6,27 +6,50 @@ AzureIoT::AzureIoT(const char* azureHost_, const char* deviceId_, const char* ke
   deviceId = deviceId_;
   key = key_;
   endPoint = azureHost + (String) "/devices/" + deviceId;
-
-  if (ttl_ < 0)
-  {
-    ttl = 0;
-  }
-  else
-  {
-    ttl = ttl_;
-  }
+  ttl = (ttl_ < 0) ? 0 : ttl_;
 }
 
 void AzureIoT::init(TelstraM1Device* IoTDevice)
 {
+  Serial.println("waiting");
   IoTDevice->waitUntilCellularSystemIsReady();
-  char tmBuf[100];
-  IoTDevice->getTime(tmBuf);
-  currentTime(tmBuf);
-
+  this->setBoardCurrentTime(IoTDevice);
   sasToken = (char*)getStringValue(generateSas((char*)key, endPoint));
 }
 
+void AzureIoT::setBoardCurrentTime(TelstraM1Device* IoTDevice)
+{
+  char tm[100];
+  IoTDevice->getTime(tm);
+  char yr[4],mnth[2],dy[2],hr[2],minu[2],sec[2];
+  yr[0]=tm[0];
+  yr[1]=tm[1];
+  yr[2]=tm[2];
+  yr[3]=tm[3];
+
+  mnth[0]=tm[5]; 
+  mnth[1]=tm[6];
+
+  dy[0]=tm[8]; 
+  dy[1]=tm[9];
+
+  hr[0]=tm[11];
+  hr[1]=tm[12];
+  
+  minu[0]=tm[14];
+  minu[1]=tm[15];
+
+  sec[0]=tm[17];
+  sec[1]=tm[18];
+  int num_yr,num_mnth,num_dy,num_hr,num_minu,num_sec;
+  sscanf(yr, "%d", &num_yr);
+  sscanf(mnth, "%d", &num_mnth);
+  sscanf(dy, "%d", &num_dy);
+  sscanf(hr, "%d", &num_hr);
+  sscanf(minu, "%d", &num_minu);
+  sscanf(sec, "%d", &num_sec);
+  setTime(num_hr,num_minu,num_sec,num_dy,num_mnth,num_yr);
+}
 
 const char* AzureIoT::getStringValue(String value)
 {
@@ -124,45 +147,11 @@ char* AzureIoT::getPostPacket()
   return post;
 }
 
-void AzureIoT::currentTime(char* timeBuffer)
-{
-  short int years = getNumber(timeBuffer, 4);
-  uint8_t months = getNumber(timeBuffer + 5, 2);
-  uint8_t days = getNumber(timeBuffer + 8, 2);
-  uint8_t hours = getNumber(timeBuffer + 11, 2);
-  uint8_t minutes = getNumber(timeBuffer + 14, 2);
-  uint8_t seconds = getNumber(timeBuffer + 17, 2);
-
-  setTime(hours, minutes, seconds, days, months, years);
-}
-
-int AzureIoT::getNumber(char *input, int len)
-{
-  char number[20];
-
-  if (len > 20)
-  {
-    return 0;
-  }
-
-  strncpy(number, input, len);
-  number[len] = '\0';
-  int value = atoi(number);
-  return value;
-}
-
 void AzureIoT::newSas(int newTime)
 {
   delete[] sasToken;
   sasToken = new char [0];
 
-  if (newTime < 0)
-  {
-    ttl = 0;
-  }
-  else
-  {
-    ttl = newTime;
-  }
+  ttl = (newTime < 0) ? 0 : newTime;
   sasToken = (char*)getStringValue(generateSas((char*)key, endPoint));
 }

--- a/TELSTRA - RELEASE LIBRARIES AND EXAMPLES 05.04.2018/TEL-IOT5 - Arduino PRE-RELEASE LIBRARIES AND EXAMPLES 05.04.2018/Telstra Examples/8. Azure POST/azureIoT.h
+++ b/TELSTRA - RELEASE LIBRARIES AND EXAMPLES 05.04.2018/TEL-IOT5 - Arduino PRE-RELEASE LIBRARIES AND EXAMPLES 05.04.2018/Telstra Examples/8. Azure POST/azureIoT.h
@@ -18,13 +18,12 @@ public:
 	void init(TelstraM1Device* IoTDevice);
 
 protected:
-    String urlEncode(const char* msg);
+    	String urlEncode(const char* msg);
 	const char* getStringValue(String value);
 
 private:
+	void setBoardCurrentTime(TelstraM1Device* IoTDevice);
 	String generateSas(char* key, String endPointUri);
-	void currentTime(char* timeBuffer);
-	int getNumber(char *input, int len);
 
 	time_t  sasExpiryTime = 0;
 	char* sasToken = new char[0];


### PR DESCRIPTION
1- Deleting:
- AzureIoT::currentTime
- AzureIoT::getNumber

2- Replacing TTL if statements in AzureIoT::AzureIoT and AzureIoT::newSas with conditional operators.